### PR TITLE
revise mochaPhantomJS inject and run until after callPhantom

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Your HTML file structure should look something like this. The reporter set below
     <script src="mocha.js"></script>
     <script src="chai.js"></script>
     <script>
-      mocha.ui('bdd'); 
+      mocha.ui('bdd');
       mocha.reporter('html');
       expect = chai.expect;
     </script>

--- a/test/blank.html
+++ b/test/blank.html
@@ -2,6 +2,9 @@
   <head>
     <title>Blank Page</title>
     <meta charset="utf-8">
+    <script type="text/javascript">
+      if (window.mochaPhantomJS) window.mochaPhantomJS.run();
+    </script>
   </head>
   <body>
   </body>


### PR DESCRIPTION
Change initialization procedure such that instead of injecting the core extensions
immediately after page load and then loop watching for
window.mochaPhantomJS.started 

Instead, start the initialize on mochaPhantomJS.run().
This uses window.callPhantom('mochaPhantomJS.run')
as the trigger to begin augmenting and running.
(so it requires phantomJS 1.6+, current version is 1.7)

In this way, mocha is fully loaded and mochaPhantomJS is ready to be overlayed
(process.stdout exists, ...) and then we can immediately start the run.

I had to add mochaPhantomJS.run() to the blank page test HTML
since it won't even start the initialization and check process unless
this is called.

I tried to make the minimum changes to get this working, you could
rework the @waitForRunMocha now since it doesn't really need a loop,
we know that when called, mocha has been loaded.
