### PR TITLE
Fails with Chai 1.4.0 in mocha's string diff code

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "commander": "~ 1.0.5"
   },
   "devDependencies": {
-    "chai": "1.2.x",
+    "chai": ">= 1.4.x",
     "async": "0.1.22",
     "coffee-script": "1.4.x",
     "requirejs": "2.0.6"

--- a/test/lib/failing.js
+++ b/test/lib/failing.js
@@ -21,7 +21,7 @@
       return expect(false).to.be["true"];
     });
     return it('fails 3', function() {
-      return expect(false).to.be["true"];
+      return expect('false').to.equal('true');
     });
   });
 

--- a/test/src/failing.coffee
+++ b/test/src/failing.coffee
@@ -8,5 +8,5 @@ describe 'Tests Failing', ->
 
   it 'fails 1', -> expect(false).to.be.true
   it 'fails 2', -> expect(false).to.be.true
-  it 'fails 3', -> expect(false).to.be.true
+  it 'fails 3', -> expect('false').to.equal('true')
 


### PR DESCRIPTION
This pull request reveals a problem with the interaction of
Chai 1.4.0, mocha's browser package, and mocha-phantomjs. Because
of the complexity, I'm not sure how, or even where, to fix it.

The problem presents itself when you have a failing equality
assertion on strings, e.g. `expect('false').to.equal('true')`.
The failure mode is that the following message is printed, and
then the mocha-phantomjs process hangs:

```
TypeError: 'undefined' is not a function (evaluating 'diff['diff' + type](err.actual, err.expected)')

  file:///Users/john/Development/mocha-phantomjs/node_modules/mocha/mocha.js:1697 in errorDiff
  file:///Users/john/Development/mocha-phantomjs/node_modules/mocha/mocha.js:1517
```

This error points to an [`errorDiff`](https://github.com/visionmedia/mocha/blob/2a8efb22f118d4e714546ee9cd90a2ccf08f2b8a/mocha.js#L1697) function in mocha.js. The `diff` object there is from [requiring](https://github.com/visionmedia/mocha/blob/2a8efb22f118d4e714546ee9cd90a2ccf08f2b8a/mocha.js#L1349) `browser/diff`, which is an [empty stub](https://github.com/visionmedia/mocha/blob/2a8efb22f118d4e714546ee9cd90a2ccf08f2b8a/mocha.js#L60)
in the browser package.

I believe this has never worked, but didn't manifest until Chai 1.4.0 because before that the errors Chai produced had no [`actual`](https://github.com/visionmedia/mocha/blob/2a8efb22f118d4e714546ee9cd90a2ccf08f2b8a/mocha.js#L1502) property.

/cc @visionmedia
