### PR TITLE
Fix error code 127 on Windows

### DIFF
--- a/bin/mocha-phantomjs
+++ b/bin/mocha-phantomjs
@@ -85,6 +85,9 @@ var spawnArgs = [script, page, reporter, config];
 var phantomjs;
 for (var i=0; i < module.paths.length; i++) {
   var bin = path.join(module.paths[i], '.bin/phantomjs');
+  if (process.platform === 'win32') {
+    bin += '.cmd';
+  }
   if (exists(bin)) {
     phantomjs = spawn(bin, spawnArgs);
     break;


### PR DESCRIPTION
I'm trying to use mocha-phantomjs together with phantomjs package on Windows. Its execution fails and returns error code 127. 

Note that I'm new to Node.js, so I'm not sure this is the best way how to fix this.
