### PR TITLE
Change customizeProcessStdout to customizeConsole for List reporter

### DIFF
--- a/lib/mocha-phantomjs.coffee
+++ b/lib/mocha-phantomjs.coffee
@@ -189,7 +189,7 @@ class List extends Reporter
       return if string is process.cursor.deleteLine or string is process.cursor.beginningOfLine
       console.log string
 
-  customizeProcessStdout: (options) ->
+  customizeConsole: (options) ->
     process.cursor.CRMatcher = /\u001b\[90m.*:\s\u001b\[0m/
     process.cursor.CRCleaner = (string) -> process.cursor.up + process.cursor.deleteLine + string + process.cursor.up + process.cursor.up
     origLog = console.log


### PR DESCRIPTION
It had to customizeProcessStdout methods in the same class. Changing it to customizeConsole like the Spec reporter.
