### PR TITLE
Should fail when there is a page error

### DIFF
--- a/lib/mocha-phantomjs.coffee
+++ b/lib/mocha-phantomjs.coffee
@@ -49,6 +49,10 @@ class Reporter
     @page.addCookie(cookie) for cookie in @config.cookies
     @page.viewportSize = @config.viewportSize if @config.viewportSize
     @page.onConsoleMessage = (msg) -> console.log msg
+    @page.onError = (msg, traces) =>
+      for {line, file}, index in traces
+        traces[index] = "  #{file}:#{line}"
+      @fail "#{msg}\n\n#{traces.join '\n'}"
     @page.onInitialized = =>
       @page.evaluate ->
         window.mochaPhantomJS =

--- a/test/error.html
+++ b/test/error.html
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <title>Tests Cookie</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
+  </head>
+  <body>
+    <div id="mocha"></div>
+    <script src="../node_modules/mocha/mocha.js"></script>
+    <script>
+      mocha.ui('bdd');
+      mocha.reporter('html');
+    </script>
+    <script>
+      unknownFunctionCall();
+
+      if (window.mochaPhantomJS) {
+        mochaPhantomJS.run();
+      } else {
+        mocha.run();
+      }
+    </script>
+  </body>
+</html>
+

--- a/test/lib/mocha-phantomjs.js
+++ b/test/lib/mocha-phantomjs.js
@@ -77,6 +77,12 @@
         return expect(stdout).to.match(/Failed to start mocha: Init timeout/);
       });
     });
+    it('returns a failure code when there is a page error', function(done) {
+      return this.runner(done, [fileURL('error')], function(code, stdout, stderr) {
+        expect(code).to.equal(1);
+        return expect(stdout).to.match(/ReferenceError/);
+      });
+    });
     it('does not fail when an iframe is used', function(done) {
       return this.runner(done, [fileURL('iframe')], function(code, stdout, stderr) {
         expect(stdout).to.not.match(/Failed to load the page\./m);

--- a/test/src/mocha-phantomjs.coffee
+++ b/test/src/mocha-phantomjs.coffee
@@ -55,6 +55,11 @@ describe 'mocha-phantomjs', ->
       expect(code).to.equal 255
       expect(stdout).to.match /Failed to start mocha: Init timeout/
 
+  it 'returns a failure code when there is a page error', (done) ->
+    @runner done, [fileURL('error')], (code, stdout, stderr) ->
+      expect(code).to.equal 1
+      expect(stdout).to.match /ReferenceError/
+
   it 'does not fail when an iframe is used', (done) ->
     @runner done, [fileURL('iframe')], (code, stdout, stderr) ->
       expect(stdout).to.not.match /Failed to load the page\./m


### PR DESCRIPTION
It seems that `mocha-phantomjs` ignores page errors and exists with 0. This can completely disable entire spec suits if there's a reference error for example.

This patch adds `onError` handler and fails the test if there's a page error.
