### PR TITLE
throw phantomjs error

### DIFF
--- a/bin/mocha-phantomjs
+++ b/bin/mocha-phantomjs
@@ -115,6 +115,9 @@ function spawnPhantomJS(cmdPath, args) {
     if (code === 127) { print("Perhaps phantomjs is not installed?\n"); }
     process.exit(code);
   });
+  phantomjs.on('error', function(error){
+    throw error;
+  });
 }
 
 function getCmdFromPath(cmdPath, callback) {


### PR DESCRIPTION
Phantomjs errors are currently swalled.

Now phantomjs debug will be easier.
