### PR TITLE
Exit with 1 if no exit code at all

### DIFF
--- a/bin/mocha-phantomjs
+++ b/bin/mocha-phantomjs
@@ -140,7 +140,7 @@ function spawnPhantomJS(cmdPath, args) {
         if (phantomjs.signalCode !== null) {
           print("phantomjs terminated with signal " + phantomjs.signalCode + "\n");
         }
-        code = 1;
+        code = -1;
         break;
       case 127:
         print("Perhaps phantomjs is not installed?\n");


### PR DESCRIPTION
In case of `PhantomJS` crash `code` will be equal to `null` and will be converted to `0 (SUCCESS)` - so we need to exit with some error code in such case.
