### PR TITLE
Ensure that a custom reporter is a file

### DIFF
--- a/bin/mocha-phantomjs
+++ b/bin/mocha-phantomjs
@@ -5,6 +5,9 @@ var program = require('commander'),
          fs = require('fs'),
        path = require('path'),
      exists = fs.existsSync || path.existsSync,
+ fileExists = function (path) {
+                return fs.existsSync(path) && !fs.statSync(path).isDirectory();
+              },
         cwd = process.cwd(),
     cookies = [],
     headers = {},
@@ -103,9 +106,9 @@ var config = JSON.stringify({
 });
 
 if (reporter) {
-  if (exists(reporter)) {
+  if (fileExists(reporter)) {
     reporter = path.resolve(process.cwd(), reporter);
-  } else if (exists(reporter + '.js')) {
+  } else if (fileExists(reporter + '.js')) {
     reporter = path.resolve(process.cwd(), reporter + '.js');
   }
 }

--- a/test/mocha-phantomjs.coffee
+++ b/test/mocha-phantomjs.coffee
@@ -41,6 +41,12 @@ describe 'mocha-phantomjs', ->
       expect(code).to.equal 1
       expect(stdout).to.match /Unable to open file 'nonesuch'/
 
+  it 'returns a success code when a directory exists with the same name as a built-in runner', (done) ->
+    fs.mkdir 'spec'
+    @runner done, ['-R', 'spec', fileURL('passing')], (code, stdout, stderr) ->
+      fs.rmdir 'spec'
+      expect(code).to.equal 0
+
   it 'returns a failure code when mocha can not be found on the page', (done) ->
     @runner done, [fileURL('blank')], (code, stdout, stderr) ->
       expect(code).to.equal 1


### PR DESCRIPTION
Fixes the case where `mocha-phantomjs` is run from a directory that has a `spec` directory.
