### PR TITLE
Add higher mocha version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "phantomjs": "~1.9.1"
   },
   "dependencies" : {
-    "mocha"     : "1.13.x",
+    "mocha"     : "~1.20.1",
     "commander" : "1.2.x"
   },
   "devDependencies" : {


### PR DESCRIPTION
Mocha updated a lot of things like XUNIT reporters, etc. It's a must the have the highest version number all the time, its impossible to keep up with fixed versions.
