### PR TITLE
Improve PhantomJS version check so PhantomJS 2 can be used as well.

### DIFF
--- a/lib/mocha-phantomjs.coffee
+++ b/lib/mocha-phantomjs.coffee
@@ -164,7 +164,7 @@ class Reporter
     catch error
       false
 
-if phantom.version.major < 1 or (phantom.version.major = 1 and phantom.version.minor < 9)
+if phantom.version.major < 1 or (phantom.version.major is 1 and phantom.version.minor < 9)
   console.log 'mocha-phantomjs requires PhantomJS > 1.9.1'
   phantom.exit -1
 


### PR DESCRIPTION
I tried to use PhantomJS 2 (still in development) with mocha-phantomjs and stumbled on this version checking which excluded me from trying it. It looks like everything works, except that some tests keep failing on my machine (even without these modifications).
