### PR TITLE
Adding sendEvent to the callPhantom callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ If you want to generate a screenshot for each test failure you could add the fol
   })
 ```
 
+# Send Events
+
+To request events be sent to the PhantomJS page, call callPhantom with an object containing `sendEvent` and an array of the standard PhantomJS sendEvent parameters:
+
+```javascript
+  callPhantom({sendEvent: ['keydown', 16777235]}); //Press the up arrow key
+```
+
 # Supported Reporters
 
 Mocha-phantomjs does not scrap the web page under test! No other PhantomJS driver stacks up to our runner support. Some have used a debounce method to keep duplicate messages in the spec reporter from showing up twice. Loosing one of Mocha's console reporters neatest features, initial test start feedback. The animation below is an example of how our runner script fully compiles with expected Mocha behavior.

--- a/lib/mocha-phantomjs.coffee
+++ b/lib/mocha-phantomjs.coffee
@@ -78,6 +78,8 @@ class Reporter
         @waitForRunMocha() if @injectJS()
       else if typeof data?.screenshot is "string"
         @page.render(data.screenshot + ".png")
+      else if data?.hasOwnProperty 'sendEvent'
+        @page.sendEvent.apply(this, data.sendEvent)
       true
 
   onLoadFailed: ->

--- a/test/lib/send-event.js
+++ b/test/lib/send-event.js
@@ -1,0 +1,13 @@
+expect = (chai && chai.expect) || require('chai').expect;
+
+describe('sendEvent', function() {
+  it('Send a keydown event', function(done) {
+    if (window.callPhantom) {
+      window.onkeydown = function(e) {
+        expect(e.keyCode).to.eql(38);
+        done();
+      }
+      window.callPhantom({sendEvent: ['keydown', 16777235]});
+    }
+  });
+});

--- a/test/mocha-phantomjs.coffee
+++ b/test/mocha-phantomjs.coffee
@@ -177,6 +177,20 @@ describe 'mocha-phantomjs', ->
           expect(fs.existsSync(fileName)).to.equal(true)
           fs.unlinkSync(fileName)
 
+    describe 'send-event', ->
+
+      ###
+      $ ./bin/mocha-phantomjs -R spec test/send-event.html
+      $ mocha -r chai/chai.js -R spec --globals chai.expect test/lib/send-event.js
+      ###
+
+      before ->
+        @args = [fileURL('send-event')]
+
+      it 'Send a keydown event', (done) ->
+        @runner done, @args, (code, stdout, stderr) ->
+          expect(code).to.equal 0
+
     describe 'requirejs', ->
 
       before ->

--- a/test/send-event.html
+++ b/test/send-event.html
@@ -1,0 +1,26 @@
+<html>
+  <head>
+    <title>Many Tests</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
+  </head>
+  <body>
+    <div id="mocha"></div>
+    <script src="../node_modules/mocha/mocha.js"></script>
+    <script src="../node_modules/chai/chai.js"></script>
+    <script>
+      mocha.ui('bdd'); 
+      mocha.reporter('html');
+      expect = chai.expect;
+    </script>
+    <script src="lib/send-event.js"></script>
+    <script>
+      if (window.mochaPhantomJS) {
+        mochaPhantomJS.run();
+      } else {
+        mocha.run();
+      }
+    </script>
+  </body>
+</html>
+


### PR DESCRIPTION
I needed to be able to request events be sent to the phantom web page from inside my tests, so I added it as an option in the callPhantom callback.  