### PR TITLE
Uses `require.resolve` to get the realpath of mocha-phantomjs-core.js

### DIFF
--- a/bin/mocha-phantomjs
+++ b/bin/mocha-phantomjs
@@ -93,7 +93,7 @@ program.parse(process.argv);
 if (!program.args.length) { program.outputHelp(); process.exit(1); };
 if (program.agent) { settings.userAgent = program.agent; }
 
-var script   = fs.realpathSync(__dirname + '/../node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js');
+var script   = require.resolve('mocha-phantomjs-core/mocha-phantomjs-core.js');
 var reporter = program.reporter;
 var page     = function(){
   var arg = program.args[0];


### PR DESCRIPTION
To fixes #204