### PR TITLE
Update PhantomJS dependency to allow newer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test": "mocha --harmony --compilers coffee:coffee-script/register test/mocha-phantomjs.coffee -t 5000"
   },
   "dependencies": {
-    "phantomjs": "1.9.7-15",
+    "phantomjs": "~1.9.7-15",
     "mocha-phantomjs-core": "^1.1.0",
     "commander": "^2.8.1"
   },


### PR DESCRIPTION
This will help projects using mocha-phantomjs and other PhantomJS dependent tools to only have to download one version of PhantomJS per checkout. This will save valuable resources for both bitbucket and users.