### PR TITLE
Switch to phantomjs-prebuilt@2.1.3

### DIFF
--- a/bin/mocha-phantomjs
+++ b/bin/mocha-phantomjs
@@ -76,7 +76,7 @@ program
   .option('-C, --no-color',              'disable color escape codes')
   .option('-p, --path <path>',           'path to PhantomJS binary')
   .option('--ignore-resource-errors',    'ignore resource errors');
-  
+
 program.on('--help', function(){
   console.log('  Any other options are passed to phantomjs (see `phantomjs --help`)');
   console.log('');
@@ -135,7 +135,7 @@ if (program.path) {
     process.exit(-2);
   }
 } else {
-  phantomPath = require('phantomjs').path || '/usr/local/bin/phantomjs';
+  phantomPath = require('phantomjs-prebuilt').path || '/usr/local/bin/phantomjs';
 }
 
 function launchFailure(e) {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test": "mocha --harmony --compilers coffee:coffee-script/register test/mocha-phantomjs.coffee -t 5000"
   },
   "dependencies": {
-    "phantomjs": "1.9.7-15",
+    "phantomjs-prebuilt": "2.1.3",
     "mocha-phantomjs-core": "^1.1.0",
     "commander": "^2.8.1"
   },


### PR DESCRIPTION
Thus upgrading to Phantom.JS 2.1.1

@nathanboktae, I saw your comment on #175, and I agree that bring-your-own-binary would be even better in the long run.