### PR TITLE
Bump phantomjs package to latest patch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test": "mocha --harmony --compilers coffee:coffee-script/register test/mocha-phantomjs.coffee -t 5000"
   },
   "dependencies": {
-    "phantomjs": "1.9.7-15",
+    "phantomjs": "1.9.20",
     "mocha-phantomjs-core": "^1.1.0",
     "commander": "^2.8.1"
   },


### PR DESCRIPTION
The current version of PhantomJS is [having issues](https://github.com/Medium/phantomjs/issues/522) with Bitbucket, which serves the archive for the main executable.

Without attempting a major version bump (already discussed and apparently stagnating in https://github.com/nathanboktae/mocha-phantomjs/issues/175), this bumps from 1.9.7-15 to [1.9.20](https://github.com/Medium/phantomjs/releases/tag/v1.9.20) as the goal is to prevent all CI tools to fail on projects using `mocha-phantomjs`.