### PR TITLE
Don't use process.exit, but set exit code

### DIFF
--- a/bin/mocha-phantomjs
+++ b/bin/mocha-phantomjs
@@ -76,7 +76,7 @@ program
   .option('-C, --no-color',              'disable color escape codes')
   .option('-p, --path <path>',           'path to PhantomJS binary')
   .option('--ignore-resource-errors',    'ignore resource errors');
-  
+
 program.on('--help', function(){
   console.log('  Any other options are passed to phantomjs (see `phantomjs --help`)');
   console.log('');
@@ -90,7 +90,7 @@ program.on('--help', function(){
 
 program.parse(process.argv);
 
-if (!program.args.length) { program.outputHelp(); process.exit(1); };
+if (!program.args.length) { program.outputHelp(); process.exitCode = 9; return; };
 if (program.agent) { settings.userAgent = program.agent; }
 
 var script   = require.resolve('mocha-phantomjs-core/mocha-phantomjs-core.js');
@@ -132,7 +132,8 @@ if (program.path) {
   phantomPath = path.resolve(program.path);
   if (!exists(phantomPath)) {
     console.error("PhantomJS does not exist at '" + program.path + "'");
-    process.exit(-2);
+    process.exitCode = 127;
+    return;
   }
 } else {
   phantomPath = require('phantomjs').path || '/usr/local/bin/phantomjs';
@@ -143,7 +144,7 @@ function launchFailure(e) {
   if (!program.path) {
     console.error('You can specify an explicit path to phantomjs via the `-p` option.');
   }
-  process.exit(-2);
+  process.exitCode = 1;
 }
 
 var unknown = program.parseOptions(process.argv).unknown.filter(function(u) {
@@ -159,12 +160,17 @@ try {
       if (phantomjs.signalCode !== null) {
         console.log("phantomjs terminated with signal " + phantomjs.signalCode);
       }
-      code = -1;
+      code = 1;
     } else if (code === 127) {
-      console.log("Perhaps phantomjs is not installed?");
+      console.log("Perhaps phantomjs is not installed ?");
     }
 
-    process.exit(code);
+    process.exitCode = code;
+
+    // Adds a final line break before exit for better cli experience.
+    process.once('beforeExit', function () {
+      process.stdout.write('\n');
+    });
   });
   phantomjs.on('error', launchFailure);
 }

--- a/bin/mocha-phantomjs
+++ b/bin/mocha-phantomjs
@@ -90,7 +90,7 @@ program.on('--help', function(){
 
 program.parse(process.argv);
 
-if (!program.args.length) { program.outputHelp(); process.exitCode = 9; return; };
+if (!program.args.length) { program.outputHelp(); process.exitCode = 1; return; };
 if (program.agent) { settings.userAgent = program.agent; }
 
 var script   = require.resolve('mocha-phantomjs-core/mocha-phantomjs-core.js');
@@ -132,7 +132,7 @@ if (program.path) {
   phantomPath = path.resolve(program.path);
   if (!exists(phantomPath)) {
     console.error("PhantomJS does not exist at '" + program.path + "'");
-    process.exitCode = 127;
+    process.exitCode = -2;
     return;
   }
 } else {
@@ -144,7 +144,7 @@ function launchFailure(e) {
   if (!program.path) {
     console.error('You can specify an explicit path to phantomjs via the `-p` option.');
   }
-  process.exitCode = 1;
+  process.exitCode = -2;
 }
 
 var unknown = program.parseOptions(process.argv).unknown.filter(function(u) {

--- a/test/mocha-phantomjs.coffee
+++ b/test/mocha-phantomjs.coffee
@@ -27,7 +27,7 @@ describe 'mocha-phantomjs', ->
 
   it 'returns a failure code and shows usage when no args are given', ->
     { code, stdout } = yield run []
-    code.should.equal 1
+    code.should.equal 9
     stdout.should.match /Usage: mocha-phantomjs/
 
   it 'returns a failure code and notifies of bad url when given one', ->

--- a/test/mocha-phantomjs.coffee
+++ b/test/mocha-phantomjs.coffee
@@ -27,7 +27,7 @@ describe 'mocha-phantomjs', ->
 
   it 'returns a failure code and shows usage when no args are given', ->
     { code, stdout } = yield run []
-    code.should.equal 9
+    code.should.equal 1
     stdout.should.match /Usage: mocha-phantomjs/
 
   it 'returns a failure code and notifies of bad url when given one', ->


### PR DESCRIPTION
Hi,

I had some problems with process exiting before stdout write is finished.
I got this when using json-cov mocha reporter, which is dumping lots of data to stdout when there's lots of tests and many lines of code.

With this commit, the mocha-phantomjs executable will no longer force process to exit quickly. It will wait for the process to exit naturally, and the expected exit code will be used.

This behavior is recommended in nodejs documentation : 
https://nodejs.org/api/process.html#process_process_exit_code

I also changed exit codes for positive codes 

Hope you like it ;)